### PR TITLE
Removed filename.lower() from the Audiofile class. Now usual uppercas…

### DIFF
--- a/pymir/AudioFile.py
+++ b/pymir/AudioFile.py
@@ -14,24 +14,25 @@ import scipy.io.wavfile
 from pymir import Frame
 import pyaudio
 
+
 class AudioFile(Frame.Frame):
-    
+
     def __new__(subtype, shape, dtype=float, buffer=None, offset=0,
-          strides=None, order=None):
+                strides=None, order=None):
         # Create the ndarray instance of our type, given the usual
         # ndarray input arguments.  This will call the standard
         # ndarray constructor, but return an object of our type.
         # It also triggers a call to InfoArray.__array_finalize__
         obj = numpy.ndarray.__new__(subtype, shape, dtype, buffer, offset, strides,
-                         order)
-        
+                                    order)
+
         obj.sampleRate = 0
         obj.channels = 1
         obj.format = pyaudio.paFloat32
-        
+
         # Finally, we must return the newly created object:
         return obj
-    
+
     def __array_finalize__(self, obj):
         # ``self`` is a new object resulting from
         # ndarray.__new__(InfoArray, ...), therefore it only has
@@ -44,7 +45,8 @@ class AudioFile(Frame.Frame):
         #    (we're in the middle of the InfoArray.__new__
         #    constructor, and self.info will be set when we return to
         #    InfoArray.__new__)
-        if obj is None: return
+        if obj is None:
+            return
         # From view casting - e.g arr.view(InfoArray):
         #    obj is arr
         #    (type(obj) can be InfoArray)
@@ -56,44 +58,45 @@ class AudioFile(Frame.Frame):
         # method sees all creation of default objects - with the
         # InfoArray.__new__ constructor, but also with
         # arr.view(InfoArray).
-        
+
         self.sampleRate = getattr(obj, 'sampleRate', None)
         self.channels = getattr(obj, 'channels', None)
         self.format = getattr(obj, 'format', None)
-        
+
         # We do not need to return anything
-    
+
     @staticmethod
     def open(filename, sampleRate=44100):
         """
         Open a file (WAV or MP3), return instance of this class with data loaded in
         Note that this is a static method. This is the preferred method of constructing this object
         """
-        filename = filename.lower()
-        
-        if filename.endswith('mp3') or filename.endswith('m4a'):
-            
-            ffmpeg = Popen([
-            "ffmpeg",
-            "-i", filename,
-            "-vn", "-acodec", "pcm_s16le", # Little Endian 16 bit PCM
-            "-ac", "1", "-ar", str(sampleRate), # -ac = audio channels (1)
-            "-f", "s16le", "-"], # -f wav for WAV file
-            stdin = PIPE, stdout = PIPE, stderr = open(os.devnull, "w"))
+        _, ext = os.path.splitext(filename)
 
-            rawData =  ffmpeg.stdout
+
+        if ext.endswith('mp3') or ext.endswith('m4a'):
+
+            ffmpeg = Popen([
+                "ffmpeg",
+                "-i", filename,
+                "-vn", "-acodec", "pcm_s16le",  # Little Endian 16 bit PCM
+                "-ac", "1", "-ar", str(sampleRate),  # -ac = audio channels (1)
+                "-f", "s16le", "-"],  # -f wav for WAV file
+                stdin=PIPE, stdout=PIPE, stderr=open(os.devnull, "w"))
+
+            rawData = ffmpeg.stdout
 
             mp3Array = numpy.fromstring(rawData.read(), numpy.int16)
             mp3Array = mp3Array.astype('float32') / 32767.0
             audioFile = mp3Array.view(AudioFile)
-        
+
             audioFile.sampleRate = sampleRate
             audioFile.channels = 1
             audioFile.format = pyaudio.paFloat32
-            
+
             return audioFile
-        
-        elif filename.endswith('wav'):
+
+        elif ext.endswith('wav'):
             sampleRate, samples = scipy.io.wavfile.read(filename)
 
             # Convert to float
@@ -107,5 +110,5 @@ class AudioFile(Frame.Frame):
             audioFile.sampleRate = sampleRate
             audioFile.channels = 1
             audioFile.format = pyaudio.paFloat32
-            
+
             return audioFile


### PR DESCRIPTION
Had the problem that I have a folder with uppercase in my path. I didn't know why exactly the filename.lower() needs to be done in the Audiofile, but I assume it is obsolete. Now the Audiofile works for usual paths.